### PR TITLE
Updates for zig 0.11.0 build system and package manager

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,25 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+
     _ = b.addModule("zigwin32", .{
-        .source_file = .{ .path = "win32.zig" },
+        .root_source_file = .{ .path = "win32.zig" },
+        .optimize = optimize,
+        .target = target,
     });
+
+    const tests = b.addTest(.{
+        .root_source_file = .{ .path = "win32.zig" },
+        .optimize = optimize,
+        .target = target,
+        .link_libc = true,
+    });
+
+    const run_tests = b.addRunArtifact(tests);
+
+    const test_step = b.step("test", "Run tests");
+
+    test_step.dependOn(&run_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,15 @@
+.{
+    .name = "zigwin32",
+    .version = "0.0.0",
+    .min_zig_version = "0.11.0",
+    .dependencies = .{},
+    .paths = .{
+        "win32",
+        "win32.zig",
+        "build.zig",
+        "build.zig.zon",
+        "zig.mod",
+        "LICENSE",
+        "README.md",
+    },
+}

--- a/win32/zig.zig
+++ b/win32/zig.zig
@@ -7,8 +7,8 @@ const root = @import("root");
 pub const UnicodeMode = enum { ansi, wide, unspecified };
 // WORKAROUND: https://github.com/ziglang/zig/issues/7979
 // using root.UNICODE causes an erroneous dependency loop, so I'm hardcoding to .wide for now
-pub const unicode_mode = UnicodeMode.wide;
-//pub const unicode_mode : UnicodeMode = if (@hasDecl(root, "UNICODE")) (if (root.UNICODE) .wide else .ansi) else .unspecified;
+// pub const unicode_mode = UnicodeMode.wide;
+pub const unicode_mode: UnicodeMode = if (@hasDecl(root, "UNICODE")) (if (root.UNICODE) .wide else .ansi) else .unspecified;
 
 pub const L = std.unicode.utf8ToUtf16LeStringLiteral;
 
@@ -50,8 +50,8 @@ pub const Guid = extern union {
     const big_endian_hex_offsets = [16]u6{ 0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34 };
     const little_endian_hex_offsets = [16]u6{ 6, 4, 2, 0, 11, 9, 16, 14, 19, 21, 24, 26, 28, 30, 32, 34 };
     const hex_offsets = switch (builtin.target.cpu.arch.endian()) {
-        .Big => big_endian_hex_offsets,
-        .Little => little_endian_hex_offsets,
+        .big => big_endian_hex_offsets,
+        .little => little_endian_hex_offsets,
     };
 
     pub fn initString(s: []const u8) Guid {
@@ -81,8 +81,8 @@ fn decodeHexByte(hex: [2]u8) u8 {
 
 test "Guid" {
     try testing.expect(std.mem.eql(u8, switch (builtin.target.cpu.arch.endian()) {
-        .Big => "\x01\x23\x45\x67\x89\xAB\xEF\x10\x32\x54\x76\x98\xba\xdc\xfe\x91",
-        .Little => "\x67\x45\x23\x01\xAB\x89\x10\xEF\x32\x54\x76\x98\xba\xdc\xfe\x91",
+        .big => "\x01\x23\x45\x67\x89\xAB\xEF\x10\x32\x54\x76\x98\xba\xdc\xfe\x91",
+        .little => "\x67\x45\x23\x01\xAB\x89\x10\xEF\x32\x54\x76\x98\xba\xdc\xfe\x91",
     }, &Guid.initString("01234567-89AB-EF10-3254-7698badcfe91").Bytes));
 }
 


### PR DESCRIPTION
Just some very minor fixes/updates.

## Changes 
- Rename `source_file` option to the new name `root_source_file` in `build.zig`
- Add `target` and `optimize` options, as those are now per-module instead of per-compilation
- Add `build.zig.zon` for compatibility with the builtin zig package manager.
- Rename usages of `Endian` fields to new name (`.Big` -> `.big`, `.Little` -> `.little`)
- Add a test step to `build.zig`
- Restore the `root.UNICODE` option since the referenced [issue](https://github.com/ziglang/zig/issues/7979) is now closed.
