### PR TITLE
Adding Microsofts Macro to cast WIN32_ERROR codes into HRESULT's

### DIFF
--- a/win32/zig.zig
+++ b/win32/zig.zig
@@ -107,6 +107,22 @@ pub const PropertyKey = extern struct {
     }
 };
 
+const c_cast = @import("std").zig.c_translation.cast;
+/// "HRESULT From WIN32 Error Code"
+/// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0c0bcf55-277e-4120-b5dc-f6115fc8dc38
+pub fn HRESULT_FROM_WIN32(x: @import("foundation.zig").WIN32_ERROR) @import("foundation.zig").HRESULT {
+    const err = @as(c_uint, @intFromEnum(x));
+    if (err <= 0) {
+        return c_cast(@import("foundation.zig").HRESULT, err);
+    } else {
+        return c_cast(@import("foundation.zig").HRESULT, ((err & @as(c_uint, 0x0000FFFF)) | @as(c_uint, (7 << 16)) | @as(c_uint, 0x80000000)));
+    }
+}
+
+test "HRESULT from WIN32_ERR" {
+    try testing.expectEqual(@as(i32, -2147023728), HRESULT_FROM_WIN32(@import("foundation.zig").WIN32_ERROR.ERROR_NOT_FOUND));
+}
+
 pub fn FAILED(hr: @import("foundation.zig").HRESULT) bool {
     return hr < 0;
 }


### PR DESCRIPTION
Needed this for

``` zig
var hr = self.enumerator.?.IMMDeviceEnumerator_GetDefaultAudioEndpoint(...)
```

where mmdeviceapi defines:

``` c
#define E_NOTFOUND HRESULT_FROM_WIN32(ERROR_NOT_FOUND)
```

which is not the same as 
``` zig
// here pub const E_NOTFOUND = @import("../zig.zig").typedConst(HRESULT, @as(i32, -2147479539));
// but should be  = @import("../zig.zig").typedConst(HRESULT, @as(i32, -2147023728));
// perhabs different  E_NOTFOUND ' s ???
pub const E_NOTFOUND = @import("../win32.zig").data.html_help.E_NOTFOUND;
```
Adding 2.1.2 HRESULT From WIN32 Error Code Macro
-> [Learn\2.1.2 HRESULT From WIN32 Error Code Macro](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0c0bcf55-277e-4120-b5dc-f6115fc8dc38) https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0c0bcf55-277e-4120-b5dc-f6115fc8dc38