### PR TITLE
chore: Fix compatibility for Zig 0.16.0-dev and update min version to 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "zigwin32",
+    .name = .zigwin32,
+    .fingerprint = 0x204432291d3dd252,
     .version = "25.0.28-preview",
-    .minimum_zig_version = "0.12.0",
+    .minimum_zig_version = "0.14.0",
     .paths = .{
         "build.zig",
         "LICENSE",


### PR DESCRIPTION
### Description
With the recent breaking changes in Zig 0.16.0-dev, the package manager now strictly enforces the presence of the `fingerprint` field in `build.zig.zon`. Additionally, certain ZON fields now expect enum literals.

This PR updates the project metadata to align with these requirements.

### Key Changes
- **Added `.fingerprint`**: Mandatory for Zig 0.16.0+ to pass the build phase.
- **Updated `.name` syntax**: Changed to the preferred enum-style literal to fix `expected enum literal` errors in new parsers.
- **Bumped `minimum_zig_version` to `0.14.0`**: Based on testing, this is the lowest version that correctly recognizes and handles the new `fingerprint` field and ZON format.

### Verification Results
- **Zig 0.16.0-dev**: `zig build` works correctly (previously failed with `missing fingerprint`).
- **Zig 0.14.0**: Verified as the minimum baseline for this format.

Fixes the build failure for all users on recent nightlies.